### PR TITLE
change btag SF's to CMVA

### DIFF
--- a/python/postprocessing/analysis/higgs/vhbb/postproc.py
+++ b/python/postprocessing/analysis/higgs/vhbb/postproc.py
@@ -12,10 +12,10 @@ from PhysicsTools.NanoAODTools.postprocessing.modules.jme.jecUncertainties impor
 #files=["root://cms-xrd-global.cern.ch//store/user/arizzi/NanoTestProd006/QCD_Pt-80to120_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer17MiniAOD-92X-NanoCrabProd006/171006_144159/0000/nanolzma_1.root"]
 #files=["lzma_1.root"]
 #files=["root://cms-xrd-global.cern.ch://store/user/arizzi/NanoTestProd004/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/NanoCrabProd004/171002_120520/0000/lzma_1.root"]
-#files=["root://cms-xrd-global.cern.ch://store/user/arizzi/NanoTestProd004/WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/NanoCrabProd004/171002_120552/0000/lzma_1.root"]
+files=["root://cms-xrd-global.cern.ch://store/user/arizzi/NanoTestProd004/WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/NanoCrabProd004/171002_120552/0000/lzma_1.root"]
 #files=["root://cms-xrd-global.cern.ch://store/user/arizzi/NanoTestProd004/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/NanoCrabProd004/171002_120644/0000/lzma_1.root"]
 #files=["root://cms-xrd-global.cern.ch://store/user/arizzi/NanoTestProd004/ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/NanoCrabProd004/171002_122256/0000/lzma_1.root"]
-files=["root://cms-xrd-global.cern.ch://store/user/arizzi/NanoTestProd004/ZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/NanoCrabProd004/171002_122221/0000/lzma_1.root"]
+#files=["root://cms-xrd-global.cern.ch://store/user/arizzi/NanoTestProd004/ZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/NanoCrabProd004/171002_122221/0000/lzma_1.root"]
 filesTTbar= [
 'root://cms-xrd-global.cern.ch//store/group/cmst3/group/nanoAOD/NanoTestProd006/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer17MiniAOD-92X-NanoCrabProd006/171006_155430/0000/nanolzma_1.root',
 ]
@@ -25,7 +25,7 @@ selection='''(Sum$(Electron_pt > 20 && Electron_mvaSpring16GP_WP90) >= 2  ||
  Sum$(Electron_pt > 20 && Electron_mvaSpring16GP_WP80) >= 1   ||
  Sum$(Muon_pt > 20 && Muon_tightId) >= 1 ||
  (Sum$(Muon_pt > 20) == 0 && Sum$(Electron_pt > 20 && Electron_mvaSpring16GP_WP90) == 0 && MET_pt > 80 ) ) 
- &&  Sum$((abs(Jet_eta)<2.5 && Jet_pt > 20 && Jet_jetId)) >= 2 && Entry$ < 10000
+ &&  Sum$((abs(Jet_eta)<2.5 && Jet_pt > 20 && Jet_jetId)) >= 2  && Entry$<1000 
 '''
 
 selectionALL='''Sum$(Electron_pt > 20 && Electron_mvaSpring16GP_WP90) >= 2  ||
@@ -34,5 +34,5 @@ selectionALL='''Sum$(Electron_pt > 20 && Electron_mvaSpring16GP_WP90) >= 2  ||
 Sum$(Jet_pt *(abs(Jet_eta)<2.5 && Jet_pt > 20 && Jet_jetId)) > 160  || 
 MET_pt > 100  || Sum$(Muon_pt > 20 && Muon_tightId) >= 1
 '''
-p=PostProcessor(".",files,selection.replace('\n',' '),"keep_and_drop.txt",[btagSF(),jecUncertAll_cppOut(),vhbb()],provenance=True)
+p=PostProcessor(".",files,selection.replace('\n',' '),"keep_and_drop.txt",[btagSFProducer("cmva"),jecUncertAll_cppOut(),vhbb()],provenance=True)
 p.run()


### PR DESCRIPTION
Update it to read btagging scale factors from CMVA rather than CSV. Still I notice that for many of the systematic variations there are many instances of the SF being 0.0, and for the nominal SF's actually it looks like the branch is not getting filled...For example

root [7] Events->Scan("Jet_btagSF_shape[hJidx[1]]:Jet_btagCMVA[hJidx[1]]:Jet_pt[hJidx[1]]:Jet_eta[hJidx[1]]:Jet_puId[hJidx[1]]:Jet_jetId[hJidx[1]]")
************************************************************************************
*    Row   * Jet_btagS * Jet_btagC * Jet_pt[hJ * Jet_eta[h * Jet_puId[ * Jet_jetId *
************************************************************************************
*        0 *         0 * -0.964355 * 25.203125 * -1.538574 *         7 *         3 *
*        1 *         0 * 0.7231445 *   38.4375 * 0.8403320 *         7 *         3 *
*        2 * 1.213e-31 * -0.954101 * 31.109375 * 2.2534179 *         4 *         3 *
*        3 * 1.213e-31 * 0.8627929 *   45.8125 * -1.380859 *         7 *         3 *
*        4 * 1.213e-31 * 0.8935546 *    75.125 * 1.9396972 *         7 *         3 *
*        5 * 1.213e-31 * -0.426513 * 24.203125 * 0.5635986 *         7 *         3 *
*        6 * 1.213e-31 * -0.935058 * 26.578125 * 0.9414062 *         7 *         3 *
*        7 * 1.213e-31 * -0.869140 * 24.609375 * 1.7670898 *         4 *         3 *
*        8 *         0 * -0.949707 *  52.34375 * -0.196990 *         4 *         3 *

